### PR TITLE
[Proposal] Logs Bridge API - Logger.WithAttributes instead of Record.AddAttributes

### DIFF
--- a/log/benchmark/bench_test.go
+++ b/log/benchmark/bench_test.go
@@ -48,7 +48,7 @@ func BenchmarkEmit(b *testing.B) {
 		logger log.Logger
 	}{
 		{"noop", noop.Logger{}},
-		{"writer", &writerLogger{w: io.Discard}},
+		{"writer", writerLogger{w: io.Discard}},
 	} {
 		b.Run(tc.name, func(b *testing.B) {
 			for _, call := range []struct {

--- a/log/benchmark/bench_test.go
+++ b/log/benchmark/bench_test.go
@@ -58,26 +58,28 @@ func BenchmarkEmit(b *testing.B) {
 				{
 					"no attrs",
 					func() {
-						r := log.Record{}
-						r.SetTimestamp(testTimestamp)
-						r.SetSeverity(testSeverity)
-						r.SetBody(testBody)
+						r := log.Record{
+							Timestamp: testTimestamp,
+							Severity:  testSeverity,
+							Body:      testBody,
+						}
 						tc.logger.Emit(ctx, r)
 					},
 				},
 				{
 					"3 attrs",
 					func() {
-						r := log.Record{}
-						r.SetTimestamp(testTimestamp)
-						r.SetSeverity(testSeverity)
-						r.SetBody(testBody)
-						r.AddAttributes(
+						r := log.Record{
+							Timestamp: testTimestamp,
+							Severity:  testSeverity,
+							Body:      testBody,
+						}
+						logger := tc.logger.WithAttributes(
 							attribute.String("string", testString),
 							attribute.Float64("float", testFloat),
 							attribute.Int("int", testInt),
 						)
-						tc.logger.Emit(ctx, r)
+						logger.Emit(ctx, r)
 					},
 				},
 				{
@@ -87,28 +89,30 @@ func BenchmarkEmit(b *testing.B) {
 					// should only be from strconv used in writerLogger.
 					"5 attrs",
 					func() {
-						r := log.Record{}
-						r.SetTimestamp(testTimestamp)
-						r.SetSeverity(testSeverity)
-						r.SetBody(testBody)
-						r.AddAttributes(
+						r := log.Record{
+							Timestamp: testTimestamp,
+							Severity:  testSeverity,
+							Body:      testBody,
+						}
+						logger := tc.logger.WithAttributes(
 							attribute.String("string", testString),
 							attribute.Float64("float", testFloat),
 							attribute.Int("int", testInt),
 							attribute.Bool("bool", testBool),
 							attribute.String("string", testString),
 						)
-						tc.logger.Emit(ctx, r)
+						logger.Emit(ctx, r)
 					},
 				},
 				{
 					"10 attrs",
 					func() {
-						r := log.Record{}
-						r.SetTimestamp(testTimestamp)
-						r.SetSeverity(testSeverity)
-						r.SetBody(testBody)
-						r.AddAttributes(
+						r := log.Record{
+							Timestamp: testTimestamp,
+							Severity:  testSeverity,
+							Body:      testBody,
+						}
+						logger := tc.logger.WithAttributes(
 							attribute.String("string", testString),
 							attribute.Float64("float", testFloat),
 							attribute.Int("int", testInt),
@@ -120,17 +124,18 @@ func BenchmarkEmit(b *testing.B) {
 							attribute.Bool("bool", testBool),
 							attribute.String("string", testString),
 						)
-						tc.logger.Emit(ctx, r)
+						logger.Emit(ctx, r)
 					},
 				},
 				{
 					"40 attrs",
 					func() {
-						r := log.Record{}
-						r.SetTimestamp(testTimestamp)
-						r.SetSeverity(testSeverity)
-						r.SetBody(testBody)
-						r.AddAttributes(
+						r := log.Record{
+							Timestamp: testTimestamp,
+							Severity:  testSeverity,
+							Body:      testBody,
+						}
+						logger := tc.logger.WithAttributes(
 							attribute.String("string", testString),
 							attribute.Float64("float", testFloat),
 							attribute.Int("int", testInt),
@@ -172,7 +177,7 @@ func BenchmarkEmit(b *testing.B) {
 							attribute.Bool("bool", testBool),
 							attribute.String("string", testString),
 						)
-						tc.logger.Emit(ctx, r)
+						logger.Emit(ctx, r)
 					},
 				},
 			} {

--- a/log/benchmark/go.mod
+++ b/log/benchmark/go.mod
@@ -12,17 +12,14 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/otel/metric v1.21.0 // indirect
-	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace go.opentelemetry.io/otel/trace => ../../trace
-
-replace go.opentelemetry.io/otel/metric => ../../metric
 
 replace go.opentelemetry.io/otel/log => ../
 
 replace go.opentelemetry.io/otel => ../..
+
+replace go.opentelemetry.io/otel/trace => ../../trace
+
+replace go.opentelemetry.io/otel/metric => ../../metric

--- a/log/benchmark/go.sum
+++ b/log/benchmark/go.sum
@@ -1,10 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
 github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
-github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
-github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/log/benchmark/spy_test.go
+++ b/log/benchmark/spy_test.go
@@ -6,6 +6,7 @@ package benchmark
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/embedded"
 )
@@ -13,8 +14,14 @@ import (
 type spyLogger struct {
 	embedded.Logger
 	Record log.Record
+	Attrs  []attribute.KeyValue
 }
 
 func (l *spyLogger) Emit(_ context.Context, r log.Record) {
 	l.Record = r
+}
+
+func (l *spyLogger) WithAttributes(attrs ...attribute.KeyValue) log.Logger {
+	l.Attrs = attrs
+	return l
 }

--- a/log/benchmark/writer_logger_test.go
+++ b/log/benchmark/writer_logger_test.go
@@ -67,17 +67,15 @@ type writerLogger struct {
 const attributesInlineCount = 5
 
 // WithAttributes appends attributes that would be emitted by the logger.
-func (l *writerLogger) WithAttributes(attrs ...attribute.KeyValue) log.Logger {
-	cl := *l // shallow copy of the logger
-
+func (l writerLogger) WithAttributes(attrs ...attribute.KeyValue) log.Logger {
 	var i int
-	for i = 0; i < len(attrs) && cl.nFront < len(cl.front); i++ {
+	for i = 0; i < len(attrs) && l.nFront < len(l.front); i++ {
 		a := attrs[i]
 		if !a.Valid() {
 			continue
 		}
-		cl.front[cl.nFront] = a
-		cl.nFront++
+		l.front[l.nFront] = a
+		l.nFront++
 	}
 
 	var attrsToSlice int
@@ -88,21 +86,21 @@ func (l *writerLogger) WithAttributes(attrs ...attribute.KeyValue) log.Logger {
 	}
 
 	if attrsToSlice == 0 {
-		return &cl
+		return l
 	}
 
-	cl.back = sliceGrow(cl.back, attrsToSlice)
+	l.back = sliceGrow(l.back, attrsToSlice)
 	for _, a := range attrs[i:] {
 		if a.Valid() {
-			cl.back = append(cl.back, a)
+			l.back = append(l.back, a)
 		}
 	}
-	cl.back = sliceClip(cl.back) // prevent append from mutating shared array
+	l.back = sliceClip(l.back) // prevent append from mutating shared array
 
-	return &cl
+	return l
 }
 
-func (l *writerLogger) Emit(_ context.Context, r log.Record) {
+func (l writerLogger) Emit(_ context.Context, r log.Record) {
 	if !r.Timestamp.IsZero() {
 		l.write("timestamp=")
 		l.write(strconv.FormatInt(r.Timestamp.Unix(), 10))

--- a/log/benchmark/writer_logger_test.go
+++ b/log/benchmark/writer_logger_test.go
@@ -20,13 +20,14 @@ import (
 
 func TestWriterLogger(t *testing.T) {
 	sb := &strings.Builder{}
-	l := &writerLogger{w: sb}
+	var l log.Logger = &writerLogger{w: sb}
 
-	r := log.Record{}
-	r.SetTimestamp(testTimestamp)
-	r.SetSeverity(testSeverity)
-	r.SetBody(testBody)
-	r.AddAttributes(
+	r := log.Record{
+		Timestamp: testTimestamp,
+		Severity:  testSeverity,
+		Body:      testBody,
+	}
+	l = l.WithAttributes(
 		attribute.String("string", testString),
 		attribute.Float64("float", testFloat),
 		attribute.Int("int", testInt),
@@ -44,20 +45,75 @@ func TestWriterLogger(t *testing.T) {
 type writerLogger struct {
 	embedded.Logger
 	w io.Writer
+
+	// The fields below are for optimizing the implementation of
+	// Attributes and AddAttributes.
+
+	// Allocation optimization: an inline array sized to hold
+	// the majority of log calls (based on examination of open-source
+	// code). It holds the start of the list of attributes.
+	front [attributesInlineCount]attribute.KeyValue
+
+	// The number of attributes in front.
+	nFront int
+
+	// The list of attributes except for those in front.
+	// Invariants:
+	//   - len(back) > 0 if nFront == len(front)
+	//   - Unused array elements are zero. Used to detect mistakes.
+	back []attribute.KeyValue
+}
+
+const attributesInlineCount = 5
+
+// WithAttributes appends attributes that would be emitted by the logger.
+func (l *writerLogger) WithAttributes(attrs ...attribute.KeyValue) log.Logger {
+	cl := *l // shallow copy of the logger
+
+	var i int
+	for i = 0; i < len(attrs) && cl.nFront < len(cl.front); i++ {
+		a := attrs[i]
+		if !a.Valid() {
+			continue
+		}
+		cl.front[cl.nFront] = a
+		cl.nFront++
+	}
+
+	var attrsToSlice int
+	for _, a := range attrs[i:] {
+		if a.Valid() {
+			attrsToSlice++
+		}
+	}
+
+	if attrsToSlice == 0 {
+		return &cl
+	}
+
+	cl.back = sliceGrow(cl.back, attrsToSlice)
+	for _, a := range attrs[i:] {
+		if a.Valid() {
+			cl.back = append(cl.back, a)
+		}
+	}
+	cl.back = sliceClip(cl.back) // prevent append from mutating shared array
+
+	return &cl
 }
 
 func (l *writerLogger) Emit(_ context.Context, r log.Record) {
-	if !r.Timestamp().IsZero() {
+	if !r.Timestamp.IsZero() {
 		l.write("timestamp=")
-		l.write(strconv.FormatInt(r.Timestamp().Unix(), 10))
+		l.write(strconv.FormatInt(r.Timestamp.Unix(), 10))
 		l.write(" ")
 	}
 	l.write("severity=")
-	l.write(strconv.FormatInt(int64(r.Severity()), 10))
+	l.write(strconv.FormatInt(int64(r.Severity), 10))
 	l.write(" ")
 	l.write("body=")
-	l.write(r.Body())
-	r.WalkAttributes(func(kv attribute.KeyValue) bool {
+	l.write(r.Body)
+	l.walkAttributes(func(kv attribute.KeyValue) bool {
 		l.write(" ")
 		l.write(string(kv.Key))
 		l.write("=")
@@ -65,6 +121,21 @@ func (l *writerLogger) Emit(_ context.Context, r log.Record) {
 		return true
 	})
 	l.write("\n")
+}
+
+// walkAttributes calls f on each [attribute.KeyValue].
+// Iteration stops if f returns false.
+func (l *writerLogger) walkAttributes(f func(attribute.KeyValue) bool) {
+	for i := 0; i < l.nFront; i++ {
+		if !f(l.front[i]) {
+			return
+		}
+	}
+	for _, a := range l.back {
+		if !f(a) {
+			return
+		}
+	}
 }
 
 func (l *writerLogger) appendValue(v attribute.Value) {
@@ -84,4 +155,27 @@ func (l *writerLogger) appendValue(v attribute.Value) {
 
 func (l *writerLogger) write(s string) {
 	_, _ = io.WriteString(l.w, s)
+}
+
+// sliceGrow increases the slice's capacity, if necessary, to guarantee space for
+// another n elements. After Grow(n), at least n elements can be appended
+// to the slice without another allocation. If n is negative or too large to
+// allocate the memory, Grow panics.
+//
+// This is a copy from https://pkg.go.dev/slices as it is not available in Go 1.20.
+func sliceGrow[S ~[]E, E any](s S, n int) S {
+	if n < 0 {
+		panic("cannot be negative")
+	}
+	if n -= cap(s) - len(s); n > 0 {
+		s = append(s[:cap(s)], make([]E, n)...)[:len(s)]
+	}
+	return s
+}
+
+// sliceClip removes unused capacity from the slice, returning s[:len(s):len(s)].
+//
+// This is a copy from https://pkg.go.dev/slices as it is not available in Go 1.20.
+func sliceClip[S ~[]E, E any](s S) S {
+	return s[:len(s):len(s)]
 }

--- a/log/benchmark/writer_logger_test.go
+++ b/log/benchmark/writer_logger_test.go
@@ -123,7 +123,7 @@ func (l writerLogger) Emit(_ context.Context, r log.Record) {
 
 // walkAttributes calls f on each [attribute.KeyValue].
 // Iteration stops if f returns false.
-func (l *writerLogger) walkAttributes(f func(attribute.KeyValue) bool) {
+func (l writerLogger) walkAttributes(f func(attribute.KeyValue) bool) {
 	for i := 0; i < l.nFront; i++ {
 		if !f(l.front[i]) {
 			return
@@ -136,7 +136,7 @@ func (l *writerLogger) walkAttributes(f func(attribute.KeyValue) bool) {
 	}
 }
 
-func (l *writerLogger) appendValue(v attribute.Value) {
+func (l writerLogger) appendValue(v attribute.Value) {
 	switch v.Type() {
 	case attribute.STRING:
 		l.write(v.AsString())
@@ -151,7 +151,7 @@ func (l *writerLogger) appendValue(v attribute.Value) {
 	}
 }
 
-func (l *writerLogger) write(s string) {
+func (l writerLogger) write(s string) {
 	_, _ = io.WriteString(l.w, s)
 }
 

--- a/log/go.mod
+++ b/log/go.mod
@@ -4,15 +4,8 @@ go 1.20
 
 require go.opentelemetry.io/otel v1.21.0
 
-require (
-	github.com/go-logr/logr v1.3.0 // indirect
-	github.com/go-logr/stdr v1.2.2 // indirect
-	go.opentelemetry.io/otel/metric v1.21.0 // indirect
-	go.opentelemetry.io/otel/trace v1.21.0 // indirect
-)
+replace go.opentelemetry.io/otel => ../
 
 replace go.opentelemetry.io/otel/trace => ../trace
 
 replace go.opentelemetry.io/otel/metric => ../metric
-
-replace go.opentelemetry.io/otel => ../

--- a/log/go.sum
+++ b/log/go.sum
@@ -1,9 +1,4 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
-github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
-github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
-github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=

--- a/log/logger.go
+++ b/log/logger.go
@@ -6,6 +6,7 @@ package log // import "go.opentelemetry.io/otel/log"
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log/embedded"
 )
 
@@ -15,4 +16,7 @@ type Logger interface {
 
 	// Emit TODO: comment.
 	Emit(ctx context.Context, record Record)
+
+	// WithAttributes TODO: comment.
+	WithAttributes(attrs ...attribute.KeyValue) Logger
 }

--- a/log/noop/noop.go
+++ b/log/noop/noop.go
@@ -17,6 +17,7 @@ package noop // import "go.opentelemetry.io/otel/log/noop"
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log"
 	"go.opentelemetry.io/otel/log/embedded"
 )
@@ -45,3 +46,8 @@ type Logger struct{ embedded.Logger }
 
 // Emit does nothing.
 func (Logger) Emit(context.Context, log.Record) {}
+
+// WithAttributes does nothing.
+func (l Logger) WithAttributes(attrs ...attribute.KeyValue) log.Logger {
+	return l
+}

--- a/log/record.go
+++ b/log/record.go
@@ -10,9 +10,6 @@ package log // import "go.opentelemetry.io/otel/log"
 import (
 	"errors"
 	"time"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 var errUnsafeAddAttrs = errors.New("unsafely called AddAttrs on copy of Record made without using Record.Clone")
@@ -20,31 +17,12 @@ var errUnsafeAddAttrs = errors.New("unsafely called AddAttrs on copy of Record m
 // Record TODO: comment.
 // TODO: Add unit tests.
 type Record struct {
-	timestamp         time.Time
-	observedTimestamp time.Time
-	severity          Severity
-	severityText      string
-	body              string
-
-	// The fields below are for optimizing the implementation of
-	// Attributes and AddAttributes.
-
-	// Allocation optimization: an inline array sized to hold
-	// the majority of log calls (based on examination of open-source
-	// code). It holds the start of the list of attributes.
-	front [attributesInlineCount]attribute.KeyValue
-
-	// The number of attributes in front.
-	nFront int
-
-	// The list of attributes except for those in front.
-	// Invariants:
-	//   - len(back) > 0 if nFront == len(front)
-	//   - Unused array elements are zero. Used to detect mistakes.
-	back []attribute.KeyValue
+	Timestamp         time.Time
+	ObservedTimestamp time.Time
+	Severity          Severity
+	SeverityText      string
+	Body              string
 }
-
-const attributesInlineCount = 5
 
 // Severity TODO: comment.
 type Severity int
@@ -77,146 +55,3 @@ const (
 	SeverityFatal3
 	SeverityFatal4
 )
-
-// Timestamp TODO: comment.
-func (r Record) Timestamp() time.Time {
-	return r.timestamp
-}
-
-// SetTimestamp TODO: comment.
-func (r *Record) SetTimestamp(t time.Time) {
-	r.timestamp = t
-}
-
-// ObservedTimestamp TODO: comment.
-func (r Record) ObservedTimestamp() time.Time {
-	return r.observedTimestamp
-}
-
-// SetObservedTimestamp TODO: comment.
-func (r *Record) SetObservedTimestamp(t time.Time) {
-	r.observedTimestamp = t
-}
-
-// Severity TODO: comment.
-func (r Record) Severity() Severity {
-	return r.severity
-}
-
-// SetSeverity TODO: comment.
-func (r *Record) SetSeverity(s Severity) {
-	r.severity = s
-}
-
-// SeverityText TODO: comment.
-func (r Record) SeverityText() string {
-	return r.severityText
-}
-
-// SetSeverityText TODO: comment.
-func (r *Record) SetSeverityText(s string) {
-	r.severityText = s
-}
-
-// Body TODO: comment.
-func (r Record) Body() string {
-	return r.body
-}
-
-// SetBody TODO: comment.
-func (r *Record) SetBody(s string) {
-	r.body = s
-}
-
-// WalkAttributes calls f on each [attribute.KeyValue] in the [Record].
-// Iteration stops if f returns false.
-func (r Record) WalkAttributes(f func(attribute.KeyValue) bool) {
-	for i := 0; i < r.nFront; i++ {
-		if !f(r.front[i]) {
-			return
-		}
-	}
-	for _, a := range r.back {
-		if !f(a) {
-			return
-		}
-	}
-}
-
-// AddAttributes appends the given [attribute.KeyValue] to the [Record]'s list of [attribute.KeyValue].
-// It omits invalid attributes.
-func (r *Record) AddAttributes(attrs ...attribute.KeyValue) {
-	var i int
-	for i = 0; i < len(attrs) && r.nFront < len(r.front); i++ {
-		a := attrs[i]
-		if !a.Valid() {
-			continue
-		}
-		r.front[r.nFront] = a
-		r.nFront++
-	}
-	// Check if a copy was modified by slicing past the end
-	// and seeing if the Attr there is non-zero.
-	if cap(r.back) > len(r.back) {
-		end := r.back[:len(r.back)+1][len(r.back)]
-		if end.Valid() {
-			// Don't panic; copy and muddle through.
-			r.back = sliceClip(r.back)
-			otel.Handle(errUnsafeAddAttrs)
-		}
-	}
-	ne := countInvalidAttrs(attrs[i:])
-	r.back = sliceGrow(r.back, len(attrs[i:])-ne)
-	for _, a := range attrs[i:] {
-		if a.Valid() {
-			r.back = append(r.back, a)
-		}
-	}
-}
-
-// Clone returns a copy of the record with no shared state.
-// The original record and the clone can both be modified
-// without interfering with each other.
-func (r Record) Clone() Record {
-	r.back = sliceClip(r.back) // prevent append from mutating shared array
-	return r
-}
-
-// AttributesLen returns the number of attributes in the Record.
-func (r Record) AttributesLen() int {
-	return r.nFront + len(r.back)
-}
-
-// countInvalidAttrs returns the number of invalid attributes.
-func countInvalidAttrs(as []attribute.KeyValue) int {
-	n := 0
-	for _, a := range as {
-		if !a.Valid() {
-			n++
-		}
-	}
-	return n
-}
-
-// sliceGrow increases the slice's capacity, if necessary, to guarantee space for
-// another n elements. After Grow(n), at least n elements can be appended
-// to the slice without another allocation. If n is negative or too large to
-// allocate the memory, Grow panics.
-//
-// This is a copy from https://pkg.go.dev/slices as it is not available in Go 1.20.
-func sliceGrow[S ~[]E, E any](s S, n int) S {
-	if n < 0 {
-		panic("cannot be negative")
-	}
-	if n -= cap(s) - len(s); n > 0 {
-		s = append(s[:cap(s)], make([]E, n)...)[:len(s)]
-	}
-	return s
-}
-
-// sliceClip removes unused capacity from the slice, returning s[:len(s):len(s)].
-//
-// This is a copy from https://pkg.go.dev/slices as it is not available in Go 1.20.
-func sliceClip[S ~[]E, E any](s S) S {
-	return s[:len(s):len(s)]
-}

--- a/log/record.go
+++ b/log/record.go
@@ -8,11 +8,8 @@
 package log // import "go.opentelemetry.io/otel/log"
 
 import (
-	"errors"
 	"time"
 )
-
-var errUnsafeAddAttrs = errors.New("unsafely called AddAttrs on copy of Record made without using Record.Clone")
 
 // Record TODO: comment.
 // TODO: Add unit tests.


### PR DESCRIPTION
Towards addressing https://github.com/open-telemetry/opentelemetry-go/pull/4725#discussion_r1419531687

Current results of `benchstat` compared to `logs-design` branch:

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/log/benchmark
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
                        │   old.txt    │                new.txt                │
                        │    sec/op    │    sec/op      vs base                │
Emit/noop/no_attrs-16     24.43n ±  3%    10.47n ±  5%  -57.13% (p=0.000 n=10)
Emit/noop/3_attrs-16      73.69n ±  8%   132.60n ±  1%  +79.93% (p=0.000 n=10)
Emit/noop/5_attrs-16      106.9n ±  3%    178.2n ±  3%  +66.70% (p=0.000 n=10)
Emit/noop/10_attrs-16     378.8n ±  2%    299.4n ±  2%  -20.97% (p=0.000 n=10)
Emit/noop/40_attrs-16     1.324µ ±  2%    1.030µ ±  2%  -22.21% (p=0.000 n=10)
Emit/writer/no_attrs-16   204.6n ±  3%    142.2n ±  3%  -30.46% (p=0.000 n=10)
Emit/writer/3_attrs-16    616.8n ±  2%    748.9n ±  3%  +21.42% (p=0.000 n=10)
Emit/writer/5_attrs-16    755.4n ±  3%    890.6n ±  2%  +17.90% (p=0.000 n=10)
Emit/writer/10_attrs-16   1.576µ ±  5%    1.614µ ±  3%        ~ (p=0.075 n=10)
Emit/writer/40_attrs-16   5.513µ ± 24%    5.616µ ±  2%        ~ (p=0.353 n=10)
Slog/no_attrs-16          463.4n ±  3%    442.1n ±  5%   -4.61% (p=0.009 n=10)
Slog/3_attrs-16           706.8n ± 11%    978.5n ±  2%  +38.44% (p=0.000 n=10)
Slog/5_attrs-16           850.9n ± 13%   1255.5n ±  5%  +47.55% (p=0.000 n=10)
Slog/10_attrs-16          1.811µ ±  1%    2.110µ ±  2%  +16.54% (p=0.000 n=10)
Slog/40_attrs-16          6.267µ ±  3%    6.966µ ± 27%  +11.16% (p=0.000 n=10)
Logr/no_attrs-16          34.81n ±  2%    25.11n ±  8%  -27.88% (p=0.000 n=10)
Logr/3_attrs-16           262.7n ± 18%    425.9n ±  4%  +62.15% (p=0.000 n=10)
Logr/5_attrs-16           362.3n ±  4%    686.1n ±  3%  +89.35% (p=0.000 n=10)
Logr/10_attrs-16          1.115µ ±  9%    1.352µ ±  1%  +21.27% (p=0.000 n=10)
Logr/40_attrs-16          5.428µ ±  3%    5.352µ ±  6%        ~ (p=0.754 n=10)
geomean                   543.5n          591.8n         +8.88%

                        │    old.txt     │                 new.txt                  │
                        │      B/op      │     B/op      vs base                    │
Emit/noop/no_attrs-16       0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
Emit/noop/3_attrs-16          0.0 ± 0%       208.0 ± 0%          ? (p=0.000 n=10)
Emit/noop/5_attrs-16          0.0 ± 0%       336.0 ± 0%          ? (p=0.000 n=10)
Emit/noop/10_attrs-16       320.0 ± 0%       656.0 ± 0%   +105.00% (p=0.000 n=10)
Emit/noop/40_attrs-16     2.250Ki ± 0%     2.641Ki ± 0%    +17.36% (p=0.000 n=10)
Emit/writer/no_attrs-16     16.00 ± 0%       16.00 ± 0%          ~ (p=1.000 n=10) ¹
Emit/writer/3_attrs-16      48.00 ± 0%      624.00 ± 0%  +1200.00% (p=0.000 n=10)
Emit/writer/5_attrs-16      48.00 ± 0%      752.00 ± 0%  +1466.67% (p=0.000 n=10)
Emit/writer/10_attrs-16     408.0 ± 0%      1432.0 ± 0%   +250.98% (p=0.000 n=10)
Emit/writer/40_attrs-16   2.570Ki ± 0%     5.570Ki ± 0%   +116.72% (p=0.000 n=10)
Slog/no_attrs-16            0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
Slog/3_attrs-16               0.0 ± 0%       240.0 ± 0%          ? (p=0.000 n=10)
Slog/5_attrs-16               0.0 ± 0%       400.0 ± 0%          ? (p=0.000 n=10)
Slog/10_attrs-16           1168.0 ± 0%      1008.0 ± 0%    -13.70% (p=0.000 n=10)
Slog/40_attrs-16          9.312Ki ± 0%     4.500Ki ± 0%    -51.68% (p=0.000 n=10)
Logr/no_attrs-16            0.000 ± 0%       0.000 ± 0%          ~ (p=1.000 n=10) ¹
Logr/3_attrs-16             128.0 ± 0%       368.0 ± 0%   +187.50% (p=0.000 n=10)
Logr/5_attrs-16             208.0 ± 0%       608.0 ± 0%   +192.31% (p=0.000 n=10)
Logr/10_attrs-16          1.344Ki ± 0%     1.188Ki ± 0%    -11.63% (p=0.000 n=10)
Logr/40_attrs-16          9.562Ki ± 0%     4.750Ki ± 0%    -50.33% (p=0.000 n=10)
geomean                                ²                 ?                        ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                        │   old.txt    │                new.txt                 │
                        │  allocs/op   │  allocs/op   vs base                   │
Emit/noop/no_attrs-16     0.000 ± 0%      0.000 ± 0%         ~ (p=1.000 n=10) ¹
Emit/noop/3_attrs-16      0.000 ± 0%      2.000 ± 0%         ? (p=0.000 n=10)
Emit/noop/5_attrs-16      0.000 ± 0%      2.000 ± 0%         ? (p=0.000 n=10)
Emit/noop/10_attrs-16     1.000 ± 0%      2.000 ± 0%  +100.00% (p=0.000 n=10)
Emit/noop/40_attrs-16     1.000 ± 0%      2.000 ± 0%  +100.00% (p=0.000 n=10)
Emit/writer/no_attrs-16   1.000 ± 0%      1.000 ± 0%         ~ (p=1.000 n=10) ¹
Emit/writer/3_attrs-16    4.000 ± 0%      6.000 ± 0%   +50.00% (p=0.000 n=10)
Emit/writer/5_attrs-16    4.000 ± 0%      6.000 ± 0%   +50.00% (p=0.000 n=10)
Emit/writer/10_attrs-16   8.000 ± 0%     10.000 ± 0%   +25.00% (p=0.000 n=10)
Emit/writer/40_attrs-16   26.00 ± 0%      28.00 ± 0%    +7.69% (p=0.000 n=10)
Slog/no_attrs-16          0.000 ± 0%      0.000 ± 0%         ~ (p=1.000 n=10) ¹
Slog/3_attrs-16           0.000 ± 0%      6.000 ± 0%         ? (p=0.000 n=10)
Slog/5_attrs-16            0.00 ± 0%      10.00 ± 0%         ? (p=0.000 n=10)
Slog/10_attrs-16          5.000 ± 0%     21.000 ± 0%  +320.00% (p=0.000 n=10)
Slog/40_attrs-16          8.000 ± 0%     81.000 ± 0%  +912.50% (p=0.000 n=10)
Logr/no_attrs-16          0.000 ± 0%      0.000 ± 0%         ~ (p=1.000 n=10) ¹
Logr/3_attrs-16           4.000 ± 0%     10.000 ± 0%  +150.00% (p=0.000 n=10)
Logr/5_attrs-16           5.000 ± 0%     15.000 ± 0%  +200.00% (p=0.000 n=10)
Logr/10_attrs-16          13.00 ± 0%      29.00 ± 0%  +123.08% (p=0.000 n=10)
Logr/40_attrs-16          40.00 ± 0%     113.00 ± 0%  +182.50% (p=0.000 n=10)
geomean                              ²                ?                       ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

Additional heap allocations from a dump creating using `go test -c -gcflags "-m=2" &> opts.txt && GODEBUG=allocfreetrace=1 ./benchmark.test -test.run=TestWriterLogger &> allocs.txt`:


opts.txt:
```
./writer_logger_test.go:30:22: ... argument escapes to heap:
./writer_logger_test.go:30:22:   flow: {heap} = &{storage for ... argument}:
./writer_logger_test.go:30:22:     from ... argument (spill) at ./writer_logger_test.go:30:22
./writer_logger_test.go:30:22:     from l.WithAttributes(... argument...) (call parameter) at ./writer_logger_test.go:30:22

./writer_logger_test.go:100:9: l escapes to heap:
./writer_logger_test.go:100:9:   flow: ~r0 = &{storage for l}:
./writer_logger_test.go:100:9:     from l (spill) at ./writer_logger_test.go:100:9
./writer_logger_test.go:100:9:     from return l (return) at ./writer_logger_test.go:100:2
./writer_logger_test.go:89:10: l escapes to heap:
./writer_logger_test.go:89:10:   flow: ~r0 = &{storage for l}:
./writer_logger_test.go:89:10:     from l (spill) at ./writer_logger_test.go:89:10
./writer_logger_test.go:89:10:     from return l (return) at ./writer_logger_test.go:89:3
```

allocs.txt:
```
tracealloc(0xc00017a000, 0x100, [4]attribute.KeyValue)
goroutine 4 [running]:
runtime.mallocgc(0x100, 0x5c4040, 0x1)
	/usr/local/go/src/runtime/malloc.go:1225 +0x707 fp=0xc000079b78 sp=0xc000079b10 pc=0x40eb27
runtime.newobject(0x5db1a0?)
	/usr/local/go/src/runtime/malloc.go:1324 +0x25 fp=0xc000079ba0 sp=0xc000079b78 pc=0x40eda5
go.opentelemetry.io/otel/log/benchmark.TestWriterLogger(0x0?)
	/home/rpajak/repos/opentelemetry-go/log/benchmark/writer_logger_test.go:30 +0x4be fp=0xc000079f70 sp=0xc000079ba0 pc=0x5a9c7e
testing.tRunner(0xc0001664e0, 0x62b328)
	/usr/local/go/src/testing/testing.go:1595 +0xff fp=0xc000079fc0 sp=0xc000079f70 pc=0x4d71bf
testing.(*T).Run.func1()
	/usr/local/go/src/testing/testing.go:1648 +0x25 fp=0xc000079fe0 sp=0xc000079fc0 pc=0x4d8145
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc000079fe8 sp=0xc000079fe0 pc=0x46d4c1
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:1648 +0x3ad

tracealloc(0xc000004300, 0x180, benchmark.writerLogger)
goroutine 4 [running]:
runtime.mallocgc(0x180, 0x5f2420, 0x1)
	/usr/local/go/src/runtime/malloc.go:1225 +0x707 fp=0xc00013b598 sp=0xc00013b530 pc=0x40eb27
runtime.convT(0x5f2420, 0xc0000081a0?)
	/usr/local/go/src/runtime/iface.go:332 +0x2e fp=0xc00013b5d0 sp=0xc00013b598 pc=0x40c56e
go.opentelemetry.io/otel/log/benchmark.writerLogger.WithAttributes({{0x0, 0x0}, {0x661980, 0xc0000182a0}, {{{0x602257, 0x6}, {0x4, 0x0, {...}, {...}}}, ...}, ...}, ...)
	/home/rpajak/repos/opentelemetry-go/log/benchmark/writer_logger_test.go:89 +0x378 fp=0xc00013b878 sp=0xc00013b5d0 pc=0x5aa2b8
go.opentelemetry.io/otel/log/benchmark.(*writerLogger).WithAttributes(0x5db1a0?, {0xc00017a000?, 0x43a89e?, 0x45a851?})
	<autogenerated>:1 +0x87 fp=0xc00013bba0 sp=0xc00013b878 pc=0x5ab3e7
go.opentelemetry.io/otel/log/benchmark.TestWriterLogger(0x0?)
	/home/rpajak/repos/opentelemetry-go/log/benchmark/writer_logger_test.go:30 +0x665 fp=0xc00013bf70 sp=0xc00013bba0 pc=0x5a9e25
testing.tRunner(0xc0001664e0, 0x62b328)
	/usr/local/go/src/testing/testing.go:1595 +0xff fp=0xc00013bfc0 sp=0xc00013bf70 pc=0x4d71bf
testing.(*T).Run.func1()
	/usr/local/go/src/testing/testing.go:1648 +0x25 fp=0xc00013bfe0 sp=0xc00013bfc0 pc=0x4d8145
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1650 +0x1 fp=0xc00013bfe8 sp=0xc00013bfe0 pc=0x46d4c1
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:1648 +0x3ad
```

As far I understand this caused by the fact that `WithAttribute` is called on an interface and thus its reference arguments (slice) are being escaped. 

From https://landontclipp.github.io/blog/2023/07/15/analyzing-go-heap-escapes/#use-of-interfaces:

>  It turns out that the Go compiler is incapable of knowing at compile-time whether the underlying type in an interface could cause the reference to escape the stack. From the perspective of the function taking an interface as an argument, this knowledge is difficult to know at compile time.

If we make sure that the method is not called on an interface then the slice would not escape

```go
	l = l.WithAttributes(
		attribute.String("string", testString),
		attribute.Float64("float", testFloat),
		attribute.Int("int", testInt),
		attribute.Bool("bool", testBool),
	).(writerLogger)
```

```
./writer_logger_test.go:30:22: ... argument does not escape
```

The same is described in:  https://youtu.be/tC4Jt3i62ns?si=TaJVJsNh-pH37FTI&t=961

**Still it is worth to note that, the Bridge API user should not assume that any particular implementation is being used. It would be against the whole idea of having API separated from the SDK.**

Moreover, the returned logger in `WithAttribute` escapes, I think it is because the value is returned as an interface which is a reference type:

```
./writer_logger_test.go:100:9: l escapes to heap:
./writer_logger_test.go:100:9:   flow: ~r0 = &{storage for l}:
./writer_logger_test.go:100:9:     from l (spill) at ./writer_logger_test.go:100:9
./writer_logger_test.go:100:9:     from return l (return) at ./writer_logger_test.go:100:2
./writer_logger_test.go:89:10: l escapes to heap:
./writer_logger_test.go:89:10:   flow: ~r0 = &{storage for l}:
./writer_logger_test.go:89:10:     from l (spill) at ./writer_logger_test.go:89:10
./writer_logger_test.go:89:10:     from return l (return) at ./writer_logger_test.go:89:3
```
