### PR TITLE
[Proposal] log: Record.Body as any

### DIFF
--- a/log/internal/writer_logger.go
+++ b/log/internal/writer_logger.go
@@ -32,8 +32,15 @@ func (l *writerLogger) Emit(ctx context.Context, r log.Record) {
 	l.write("severity=")
 	l.write(strconv.FormatInt(int64(r.Severity), 10))
 	l.write(" ")
+
 	l.write("body=")
-	l.write(r.Body)
+	if s, ok := r.Body.(string); ok {
+		l.write(s)
+	} else {
+		s := fmt.Sprint(r.Body)
+		l.write(s)
+	}
+
 	for _, kv := range r.Attributes {
 		l.write(" ")
 		l.write(string(kv.Key))

--- a/log/record.go
+++ b/log/record.go
@@ -19,7 +19,7 @@ type Record struct {
 	ObservedTimestamp time.Time
 	Severity          Severity
 	SeverityText      string
-	Body              string
+	Body              any
 	Attributes        []attribute.KeyValue
 }
 


### PR DESCRIPTION
Per https://github.com/open-telemetry/opentelemetry-go/pull/4809#discussion_r1447060882

https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-body defines `Body` as `any`.

Benefits:
- More flexible API that could support logging libraries which model log records as objects.

Drawbacks:
- Performance penalty (additional heap allocation).
- There is no popular Go logging library which uses objects as log records.

Questionable:
- It looks like the specification recommends using `string` in Bridge API per:  "First-party Applications SHOULD use a string message." as accroding to https://opentelemetry.io/docs/specs/otel/logs/#new-first-party-application-logs First-party Applications are supposed to use the log bridges that integrates with OTel through Bridge API .

Benchmarks:

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/log/internal
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
                        │   old.txt    │                new.txt                 │
                        │    sec/op    │    sec/op      vs base                 │
Emit/noop/no_attrs-16     2.667n ±  7%   13.360n ±  6%  +401.03% (p=0.000 n=10)
Emit/noop/3_attrs-16      14.80n ±  8%    21.68n ±  2%   +46.45% (p=0.000 n=10)
Emit/noop/5_attrs-16      18.31n ±  6%    23.69n ±  5%   +29.36% (p=0.000 n=10)
Emit/noop/10_attrs-16     27.32n ±  7%    29.52n ±  3%    +8.09% (p=0.003 n=10)
Emit/noop/40_attrs-16     82.37n ±  5%    69.77n ± 16%   -15.29% (p=0.005 n=10)
Emit/writer/no_attrs-16   71.41n ±  8%    64.06n ± 11%   -10.29% (p=0.000 n=10)
Emit/writer/3_attrs-16    209.8n ±  6%    157.1n ±  5%   -25.08% (p=0.000 n=10)
Emit/writer/5_attrs-16    242.5n ±  8%    176.2n ±  6%   -27.33% (p=0.000 n=10)
Emit/writer/10_attrs-16   400.1n ± 10%    312.1n ± 15%   -22.02% (p=0.000 n=10)
Emit/writer/40_attrs-16   1.386µ ±  6%    1.100µ ±  4%   -20.67% (p=0.000 n=10)
Slog/no_attrs-16          158.4n ±  9%    144.9n ±  4%    -8.49% (p=0.008 n=10)
Slog/3_attrs-16           208.8n ± 11%    237.9n ± 14%   +13.91% (p=0.041 n=10)
Slog/5_attrs-16           262.9n ±  9%    254.7n ±  6%    -3.12% (p=0.014 n=10)
Slog/10_attrs-16          487.7n ± 19%    504.5n ±  7%         ~ (p=0.353 n=10)
Slog/40_attrs-16          1.943µ ±  4%    2.108µ ±  6%    +8.52% (p=0.001 n=10)
Logr/no_attrs-16          14.48n ±  4%    37.12n ±  5%  +156.30% (p=0.000 n=10)
Logr/3_attrs-16           171.3n ± 12%    184.4n ±  7%    +7.68% (p=0.030 n=10)
Logr/5_attrs-16           268.2n ± 15%    267.9n ±  3%         ~ (p=0.796 n=10)
Logr/10_attrs-16          479.0n ±  4%    485.0n ±  8%         ~ (p=0.105 n=10)
Logr/40_attrs-16          1.858µ ±  6%    1.819µ ±  6%         ~ (p=0.280 n=10)
geomean                   144.6n          160.6n         +11.05%

                        │    old.txt     │                new.txt                │
                        │      B/op      │     B/op      vs base                 │
Emit/noop/no_attrs-16        0.00 ± 0%       16.00 ± 0%         ? (p=0.000 n=10)
Emit/noop/3_attrs-16         0.00 ± 0%       16.00 ± 0%         ? (p=0.000 n=10)
Emit/noop/5_attrs-16         0.00 ± 0%       16.00 ± 0%         ? (p=0.000 n=10)
Emit/noop/10_attrs-16        0.00 ± 0%       16.00 ± 0%         ? (p=0.000 n=10)
Emit/noop/40_attrs-16        0.00 ± 0%       16.00 ± 0%         ? (p=0.000 n=10)
Emit/writer/no_attrs-16     16.00 ± 0%       32.00 ± 0%  +100.00% (p=0.000 n=10)
Emit/writer/3_attrs-16      48.00 ± 0%       64.00 ± 0%   +33.33% (p=0.000 n=10)
Emit/writer/5_attrs-16      48.00 ± 0%       64.00 ± 0%   +33.33% (p=0.000 n=10)
Emit/writer/10_attrs-16     88.00 ± 0%      104.00 ± 0%   +18.18% (p=0.000 n=10)
Emit/writer/40_attrs-16     328.0 ± 0%       344.0 ± 0%    +4.88% (p=0.000 n=10)
Slog/no_attrs-16             0.00 ± 0%       16.00 ± 0%         ? (p=0.000 n=10)
Slog/3_attrs-16              0.00 ± 0%       16.00 ± 0%         ? (p=0.000 n=10)
Slog/5_attrs-16              0.00 ± 0%       16.00 ± 0%         ? (p=0.000 n=10)
Slog/10_attrs-16            209.0 ± 0%       225.0 ± 0%    +7.66% (p=0.000 n=10)
Slog/40_attrs-16          1.404Ki ± 0%     1.421Ki ± 0%    +1.22% (p=0.000 n=10)
Logr/no_attrs-16             0.00 ± 0%       16.00 ± 0%         ? (p=0.000 n=10)
Logr/3_attrs-16             128.0 ± 0%       144.0 ± 0%   +12.50% (p=0.000 n=10)
Logr/5_attrs-16             208.0 ± 0%       224.0 ± 0%    +7.69% (p=0.000 n=10)
Logr/10_attrs-16            418.0 ± 0%       434.0 ± 0%    +3.83% (p=0.000 n=10)
Logr/40_attrs-16          1.656Ki ± 0%     1.672Ki ± 0%    +0.94% (p=0.000 n=10)
geomean                                ¹     66.09       ?
¹ summaries must be >0 to compute geomean

                        │   old.txt    │               new.txt                │
                        │  allocs/op   │  allocs/op   vs base                 │
Emit/noop/no_attrs-16     0.000 ± 0%      1.000 ± 0%         ? (p=0.000 n=10)
Emit/noop/3_attrs-16      0.000 ± 0%      1.000 ± 0%         ? (p=0.000 n=10)
Emit/noop/5_attrs-16      0.000 ± 0%      1.000 ± 0%         ? (p=0.000 n=10)
Emit/noop/10_attrs-16     0.000 ± 0%      1.000 ± 0%         ? (p=0.000 n=10)
Emit/noop/40_attrs-16     0.000 ± 0%      1.000 ± 0%         ? (p=0.000 n=10)
Emit/writer/no_attrs-16   1.000 ± 0%      2.000 ± 0%  +100.00% (p=0.000 n=10)
Emit/writer/3_attrs-16    4.000 ± 0%      5.000 ± 0%   +25.00% (p=0.000 n=10)
Emit/writer/5_attrs-16    4.000 ± 0%      5.000 ± 0%   +25.00% (p=0.000 n=10)
Emit/writer/10_attrs-16   7.000 ± 0%      8.000 ± 0%   +14.29% (p=0.000 n=10)
Emit/writer/40_attrs-16   25.00 ± 0%      26.00 ± 0%    +4.00% (p=0.000 n=10)
Slog/no_attrs-16          0.000 ± 0%      1.000 ± 0%         ? (p=0.000 n=10)
Slog/3_attrs-16           0.000 ± 0%      1.000 ± 0%         ? (p=0.000 n=10)
Slog/5_attrs-16           0.000 ± 0%      1.000 ± 0%         ? (p=0.000 n=10)
Slog/10_attrs-16          1.000 ± 0%      2.000 ± 0%  +100.00% (p=0.000 n=10)
Slog/40_attrs-16          1.000 ± 0%      2.000 ± 0%  +100.00% (p=0.000 n=10)
Logr/no_attrs-16          0.000 ± 0%      1.000 ± 0%         ? (p=0.000 n=10)
Logr/3_attrs-16           4.000 ± 0%      5.000 ± 0%   +25.00% (p=0.000 n=10)
Logr/5_attrs-16           5.000 ± 0%      6.000 ± 0%   +20.00% (p=0.000 n=10)
Logr/10_attrs-16          9.000 ± 0%     10.000 ± 0%   +11.11% (p=0.000 n=10)
Logr/40_attrs-16          33.00 ± 0%      34.00 ± 0%    +3.03% (p=0.000 n=10)
geomean                              ¹    2.700       ?
¹ summaries must be >0 to compute geomean
```