### PR TITLE
Record with pointer receivers only

### DIFF
--- a/log/record.go
+++ b/log/record.go
@@ -153,9 +153,8 @@ func (r *Record) AddAttributes(attrs ...KeyValue) {
 // The original record and the clone can both be modified
 // without interfering with each other.
 func (r *Record) Clone() Record {
-	cloned := *r
-	cloned.back = sliceClip(r.back) // prevent append from mutating shared array
-	return cloned
+	r.back = sliceClip(r.back) // prevent append from mutating shared array
+	return *r
 }
 
 // AttributesLen returns the number of attributes in the Record.

--- a/log/record.go
+++ b/log/record.go
@@ -43,7 +43,7 @@ type Record struct {
 const attributesInlineCount = 5
 
 // Timestamp returns the time when the log record occurred.
-func (r Record) Timestamp() time.Time {
+func (r *Record) Timestamp() time.Time {
 	return r.timestamp
 }
 
@@ -54,7 +54,7 @@ func (r *Record) SetTimestamp(t time.Time) {
 
 // ObservedTimestamp returns the time when the log record was observed.
 // If unset the implementation should set it equal to the current time.
-func (r Record) ObservedTimestamp() time.Time {
+func (r *Record) ObservedTimestamp() time.Time {
 	return r.observedTimestamp
 }
 
@@ -65,7 +65,7 @@ func (r *Record) SetObservedTimestamp(t time.Time) {
 }
 
 // Severity returns the [Severity] of the log record.
-func (r Record) Severity() Severity {
+func (r *Record) Severity() Severity {
 	return r.severity
 }
 
@@ -78,7 +78,7 @@ func (r *Record) SetSeverity(s Severity) {
 // SeverityText returns severity (also known as log level) text.
 // This is the original string representation of the severity
 // as it is known at the source.
-func (r Record) SeverityText() string {
+func (r *Record) SeverityText() string {
 	return r.severityText
 }
 
@@ -90,7 +90,7 @@ func (r *Record) SetSeverityText(s string) {
 }
 
 // Body returns the the body of the log record as a strucutured value.
-func (r Record) Body() Value {
+func (r *Record) Body() Value {
 	return r.body
 }
 
@@ -101,7 +101,7 @@ func (r *Record) SetBody(v Value) {
 
 // WalkAttributes calls f on each [KeyValue] in the [Record].
 // Iteration stops if f returns false.
-func (r Record) WalkAttributes(f func(KeyValue) bool) {
+func (r *Record) WalkAttributes(f func(KeyValue) bool) {
 	for i := 0; i < r.nFront; i++ {
 		if !f(r.front[i]) {
 			return
@@ -152,13 +152,14 @@ func (r *Record) AddAttributes(attrs ...KeyValue) {
 // Clone returns a copy of the record with no shared state.
 // The original record and the clone can both be modified
 // without interfering with each other.
-func (r Record) Clone() Record {
-	r.back = sliceClip(r.back) // prevent append from mutating shared array
-	return r
+func (r *Record) Clone() Record {
+	cloned := *r
+	cloned.back = sliceClip(r.back) // prevent append from mutating shared array
+	return cloned
 }
 
 // AttributesLen returns the number of attributes in the Record.
-func (r Record) AttributesLen() int {
+func (r *Record) AttributesLen() int {
 	return r.nFront + len(r.back)
 }
 

--- a/log/record_test.go
+++ b/log/record_test.go
@@ -170,6 +170,8 @@ func TestRecordAliasingAndClone(t *testing.T) {
 	assert.Zero(t, errs)
 	assert.Equal(t, r1Attrs, attrsSlice(r1), "r1 is unchanged")
 	assert.Equal(t, append(r1Attrs, Int("p", 2)), attrsSlice(r3))
+	r3.SetSeverity(SeverityDebug)
+	assert.NotEqual(t, r3.Severity(), r1.Severity(), "r1 is unchanged")
 }
 
 func attrsSlice(r Record) []KeyValue {


### PR DESCRIPTION
Per https://github.com/open-telemetry/opentelemetry-go/pull/4809#discussion_r1466766317

On `go version go1.21.4 linux/amd64`:


```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/log/internal
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
                        │    old.txt    │                new.txt                │
                        │    sec/op     │    sec/op      vs base                │
Emit/noop/no_attrs-16      3.170n ± 10%    3.785n ±  5%  +19.44% (p=0.000 n=10)
Emit/noop/3_attrs-16       7.776n ±  6%   13.130n ± 15%  +68.84% (p=0.000 n=10)
Emit/noop/5_attrs-16       10.07n ±  9%    15.96n ±  7%  +58.62% (p=0.000 n=10)
Emit/noop/10_attrs-16      134.0n ±  7%    147.0n ± 17%   +9.74% (p=0.000 n=10)
Emit/noop/40_attrs-16      574.0n ±  9%    698.2n ±  5%  +21.64% (p=0.000 n=10)
Emit/writer/no_attrs-16    57.01n ±  2%    56.17n ±  9%        ~ (p=0.529 n=10)
Emit/writer/3_attrs-16     145.3n ±  3%    156.0n ± 19%        ~ (p=0.138 n=10)
Emit/writer/5_attrs-16     184.8n ±  6%    150.6n ±  2%  -18.48% (p=0.000 n=10)
Emit/writer/10_attrs-16    482.2n ±  5%    385.1n ±  3%  -20.16% (p=0.000 n=10)
Emit/writer/40_attrs-16    3.104µ ± 30%    1.704µ ±  4%  -45.12% (p=0.000 n=10)
Slog/no_attrs-16          151.65n ±  8%    92.76n ±  2%  -38.83% (p=0.000 n=10)
Slog/3_attrs-16            187.6n ±  3%    134.2n ±  3%  -28.46% (p=0.000 n=10)
Slog/5_attrs-16            227.9n ±  6%    167.4n ±  4%  -26.52% (p=0.000 n=10)
Slog/10_attrs-16          1003.1n ±  8%    812.4n ±  7%  -19.01% (p=0.001 n=10)
Slog/40_attrs-16           4.815µ ± 10%    6.634µ ± 15%  +37.79% (p=0.000 n=10)
Logr/no_attrs-16           6.296n ±  9%    7.549n ± 20%  +19.89% (p=0.000 n=10)
Logr/3_attrs-16            118.3n ±  7%    140.3n ± 19%  +18.60% (p=0.000 n=10)
Logr/5_attrs-16            193.8n ±  4%    218.7n ±  2%  +12.82% (p=0.000 n=10)
Logr/10_attrs-16           804.2n ±  8%    867.6n ±  7%   +7.88% (p=0.009 n=10)
Logr/40_attrs-16           5.085µ ±  3%    5.093µ ±  6%        ~ (p=1.000 n=10)
geomean                    175.9n          176.0n         +0.01%

                        │    old.txt     │                new.txt                │
                        │      B/op      │     B/op      vs base                 │
Emit/noop/no_attrs-16       0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/3_attrs-16        0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/5_attrs-16        0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/10_attrs-16       208.0 ± 0%       208.0 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/40_attrs-16     1.375Ki ± 0%     1.375Ki ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/no_attrs-16     16.00 ± 0%       16.00 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/3_attrs-16      48.00 ± 0%       48.00 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/5_attrs-16      48.00 ± 0%       48.00 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/10_attrs-16     296.0 ± 0%       296.0 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/40_attrs-16   1.695Ki ± 0%     1.695Ki ± 0%       ~ (p=1.000 n=10) ¹
Slog/no_attrs-16            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/3_attrs-16             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/5_attrs-16             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/10_attrs-16            816.0 ± 0%       816.0 ± 0%       ~ (p=1.000 n=10) ¹
Slog/40_attrs-16          6.469Ki ± 0%     6.469Ki ± 0%       ~ (p=1.000 n=10) ¹
Logr/no_attrs-16            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Logr/3_attrs-16             128.0 ± 0%       128.0 ± 0%       ~ (p=1.000 n=10) ¹
Logr/5_attrs-16             208.0 ± 0%       208.0 ± 0%       ~ (p=1.000 n=10) ¹
Logr/10_attrs-16          1.000Ki ± 0%     1.000Ki ± 0%       ~ (p=1.000 n=10) ¹
Logr/40_attrs-16          6.719Ki ± 0%     6.719Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                                ²                 +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                        │   old.txt    │               new.txt               │
                        │  allocs/op   │ allocs/op   vs base                 │
Emit/noop/no_attrs-16     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/3_attrs-16      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/5_attrs-16      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/10_attrs-16     1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/40_attrs-16     1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/no_attrs-16   1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/3_attrs-16    4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/5_attrs-16    4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/10_attrs-16   8.000 ± 0%     8.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/40_attrs-16   26.00 ± 0%     26.00 ± 0%       ~ (p=1.000 n=10) ¹
Slog/no_attrs-16          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/3_attrs-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/5_attrs-16           0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/10_attrs-16          5.000 ± 0%     5.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/40_attrs-16          8.000 ± 0%     8.000 ± 0%       ~ (p=1.000 n=10) ¹
Logr/no_attrs-16          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Logr/3_attrs-16           4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
Logr/5_attrs-16           5.000 ± 0%     5.000 ± 0%       ~ (p=1.000 n=10) ¹
Logr/10_attrs-16          13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
Logr/40_attrs-16          40.00 ± 0%     40.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                              ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

On `go version go1.20 linux/amd64`:

```
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/log/internal
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
                        │ old-go1.20.txt │            new-go1.20.txt            │
                        │     sec/op     │    sec/op     vs base                │
Emit/noop/no_attrs-16        4.801n ± 2%   2.513n ±  4%  -47.67% (p=0.009 n=10)
Emit/noop/3_attrs-16         11.62n ± 2%   12.59n ± 12%   +8.39% (p=0.000 n=10)
Emit/noop/5_attrs-16         15.40n ± 2%   17.30n ±  5%  +12.37% (p=0.000 n=10)
Emit/noop/10_attrs-16        177.3n ± 3%   189.4n ±  8%   +6.80% (p=0.000 n=10)
Emit/noop/40_attrs-16        842.0n ± 3%   882.8n ±  4%   +4.83% (p=0.002 n=10)
Emit/writer/no_attrs-16      83.10n ± 3%   75.88n ± 13%   -8.69% (p=0.029 n=10)
Emit/writer/3_attrs-16       210.4n ± 2%   210.2n ±  2%        ~ (p=0.541 n=10)
Emit/writer/5_attrs-16       243.6n ± 6%   239.4n ±  4%   -1.74% (p=0.043 n=10)
Emit/writer/10_attrs-16      556.3n ± 7%   561.2n ±  7%        ~ (p=0.684 n=10)
Emit/writer/40_attrs-16      2.352µ ± 4%   2.580µ ±  6%   +9.70% (p=0.000 n=10)
Slog/no_attrs-16             109.2n ± 3%   115.0n ± 10%   +5.36% (p=0.001 n=10)
Slog/3_attrs-16              164.7n ± 4%   168.4n ±  4%        ~ (p=0.247 n=10)
Slog/5_attrs-16              192.3n ± 4%   197.9n ±  4%   +2.89% (p=0.043 n=10)
Slog/10_attrs-16             925.9n ± 2%   955.1n ±  4%   +3.15% (p=0.001 n=10)
Slog/40_attrs-16             5.183µ ± 2%   5.280µ ±  2%   +1.87% (p=0.027 n=10)
Logr/no_attrs-16             7.382n ± 7%   7.388n ±  4%        ~ (p=0.912 n=10)
Logr/3_attrs-16              158.6n ± 9%   142.2n ± 13%  -10.31% (p=0.007 n=10)
Logr/5_attrs-16              263.5n ± 6%   221.8n ±  3%  -15.84% (p=0.000 n=10)
Logr/10_attrs-16            1035.0n ± 7%   934.4n ±  2%   -9.72% (p=0.000 n=10)
Logr/40_attrs-16             7.700µ ± 6%   5.295µ ±  2%  -31.23% (p=0.000 n=10)
geomean                      210.5n        200.7n         -4.64%

                        │ old-go1.20.txt │            new-go1.20.txt             │
                        │      B/op      │     B/op      vs base                 │
Emit/noop/no_attrs-16       0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/3_attrs-16        0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/5_attrs-16        0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/10_attrs-16       208.0 ± 0%       208.0 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/40_attrs-16     1.375Ki ± 0%     1.375Ki ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/no_attrs-16     16.00 ± 0%       16.00 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/3_attrs-16      48.00 ± 0%       48.00 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/5_attrs-16      48.00 ± 0%       48.00 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/10_attrs-16     296.0 ± 0%       296.0 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/40_attrs-16   1.695Ki ± 0%     1.695Ki ± 0%       ~ (p=1.000 n=10) ¹
Slog/no_attrs-16            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/3_attrs-16             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/5_attrs-16             0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/10_attrs-16            816.0 ± 0%       816.0 ± 0%       ~ (p=1.000 n=10) ¹
Slog/40_attrs-16          6.469Ki ± 0%     6.469Ki ± 0%       ~ (p=1.000 n=10) ¹
Logr/no_attrs-16            0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Logr/3_attrs-16             128.0 ± 0%       128.0 ± 0%       ~ (p=1.000 n=10) ¹
Logr/5_attrs-16             208.0 ± 0%       208.0 ± 0%       ~ (p=1.000 n=10) ¹
Logr/10_attrs-16          1.000Ki ± 0%     1.000Ki ± 0%       ~ (p=1.000 n=10) ¹
Logr/40_attrs-16          6.719Ki ± 0%     6.719Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                                ²                 +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                        │ old-go1.20.txt │           new-go1.20.txt            │
                        │   allocs/op    │ allocs/op   vs base                 │
Emit/noop/no_attrs-16       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/3_attrs-16        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/5_attrs-16        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/10_attrs-16       1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/noop/40_attrs-16       1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/no_attrs-16     1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/3_attrs-16      4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/5_attrs-16      4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/10_attrs-16     8.000 ± 0%     8.000 ± 0%       ~ (p=1.000 n=10) ¹
Emit/writer/40_attrs-16     26.00 ± 0%     26.00 ± 0%       ~ (p=1.000 n=10) ¹
Slog/no_attrs-16            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/3_attrs-16             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/5_attrs-16             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/10_attrs-16            5.000 ± 0%     5.000 ± 0%       ~ (p=1.000 n=10) ¹
Slog/40_attrs-16            8.000 ± 0%     8.000 ± 0%       ~ (p=1.000 n=10) ¹
Logr/no_attrs-16            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Logr/3_attrs-16             4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
Logr/5_attrs-16             5.000 ± 0%     5.000 ± 0%       ~ (p=1.000 n=10) ¹
Logr/10_attrs-16            13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
Logr/40_attrs-16            40.00 ± 0%     40.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```