### PR TITLE
Introduce Processor

### DIFF
--- a/sdk/log/processor.go
+++ b/sdk/log/processor.go
@@ -7,16 +7,16 @@ import (
 	"context"
 )
 
-// Exporter handles the delivery of log records to external receivers.
+// Processor handles the processing of log records.
 //
 // Any of the Exporter's methods may be called concurrently with itself
 // or with other methods. It is the responsibility of the Exporter to manage
 // this concurrency.
-type Exporter interface {
+type Processor interface {
 	// DO NOT CHANGE: any modification will not be backwards compatible and
 	// must never be done outside of a new major release.
 
-	// Export transmits log records to a receiver.
+	// OnEmit is called when a Record is emitted.
 	//
 	// The deadline or cancellation of the passed context must be honored. An
 	// appropriate error should be returned in these situations.
@@ -26,11 +26,9 @@ type Exporter interface {
 	// considered unrecoverable and will be reported to a configured error
 	// Handler.
 	//
-	// Implementations must not retain the records slice.
-	//
 	// Before modifying a Record, the implementation must use Record.Clone
 	// to create a copy that shares no state with the original.
-	Export(ctx context.Context, records []Record) error
+	OnEmit(ctx context.Context, record Record) error
 	// DO NOT CHANGE: any modification will not be backwards compatible and
 	// must never be done outside of a new major release.
 

--- a/sdk/log/provider.go
+++ b/sdk/log/provider.go
@@ -42,7 +42,7 @@ type LoggerProvider struct {
 
 type providerConfig struct {
 	resource                  *resource.Resource
-	exporters                 []Exporter
+	processors                []Processor
 	attributeCountLimit       int
 	attributeValueLengthLimit int
 }
@@ -124,7 +124,7 @@ func (p *LoggerProvider) Shutdown(ctx context.Context) error {
 	}
 
 	var err error
-	for _, exporter := range p.cfg.exporters {
+	for _, exporter := range p.cfg.processors {
 		err = exporter.Shutdown(ctx)
 	}
 	return err
@@ -137,7 +137,7 @@ func (p *LoggerProvider) ForceFlush(ctx context.Context) error {
 	}
 
 	var err error
-	for _, exporter := range p.cfg.exporters {
+	for _, exporter := range p.cfg.processors {
 		err = exporter.ForceFlush(ctx)
 	}
 	return err
@@ -167,15 +167,16 @@ func WithResource(res *resource.Resource) LoggerProviderOption {
 	})
 }
 
-// WithExporter associates Exporter with a LoggerProvider.
+// WithProcessor associates Processor with a LoggerProvider.
 //
 // By default, if this option is not used, the LoggerProvider will perform no
-// operations; no data will be exported without an Exporter.
+// operations; no data will be exported without a processor.
 //
-// Use NewBatchingExporter to batch log records before they are exported.
-func WithExporter(exporter Exporter) LoggerProviderOption {
+// Use NewBatchingProcessor to batch log records before they are exported.
+// Use NewSimpleProcessor to synchronously export log records.
+func WithProcessor(processor Processor) LoggerProviderOption {
 	return loggerProviderOptionFunc(func(cfg providerConfig) providerConfig {
-		cfg.exporters = append(cfg.exporters, exporter)
+		cfg.processors = append(cfg.processors, processor)
 		return cfg
 	})
 }

--- a/sdk/log/provider.go
+++ b/sdk/log/provider.go
@@ -172,6 +172,9 @@ func WithResource(res *resource.Resource) LoggerProviderOption {
 // By default, if this option is not used, the LoggerProvider will perform no
 // operations; no data will be exported without a processor.
 //
+// Each WithProcessor creates a separate pipeline. Use custom decotarators
+// for advanced scenarios such as enriching with attributes.
+//
 // Use NewBatchingProcessor to batch log records before they are exported.
 // Use NewSimpleProcessor to synchronously export log records.
 func WithProcessor(processor Processor) LoggerProviderOption {

--- a/sdk/log/simple.go
+++ b/sdk/log/simple.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package log // import "go.opentelemetry.io/otel/sdk/log"
+
+import (
+	"context"
+	"sync"
+)
+
+var _ Processor = (*SimpleProcessor)(nil)
+
+// Batcher is an processor that synchronously exports log records.
+type SimpleProcessor struct {
+	exporter Exporter
+	pool     sync.Pool
+}
+
+// NewBatchingProcessor decorates the provided exporter
+// so that the log records are batched before exporting.
+func NewSimpleProcessor(exporter Exporter) *SimpleProcessor {
+	p := &SimpleProcessor{exporter: exporter}
+	p.pool = sync.Pool{
+		New: func() any {
+			b := make([]Record, 0, 1)
+			return &b
+		},
+	}
+	return p
+}
+
+// OnEmit batches provided log record.
+func (s *SimpleProcessor) OnEmit(ctx context.Context, r Record) error {
+	records := s.pool.Get().(*[]Record)
+	defer func() {
+		*records = (*records)[:0]
+		s.pool.Put(records)
+	}()
+
+	return s.exporter.Export(ctx, *records)
+}
+
+// Shutdown shuts down the expoter.
+func (s *SimpleProcessor) Shutdown(ctx context.Context) error {
+	return s.exporter.Shutdown(ctx)
+}
+
+// ForceFlush flushes the exporter.
+func (s *SimpleProcessor) ForceFlush(ctx context.Context) error {
+	return s.exporter.ForceFlush(ctx)
+}


### PR DESCRIPTION
Introducing a `Processor` has no impact on the performance.

```
$ benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/otel/sdk/log
cpu: Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
                    │   old.txt    │               new.txt               │
                    │    sec/op    │    sec/op     vs base               │
/no_attrs/Simple-16   451.4n ±  4%   453.2n ±  3%       ~ (p=0.684 n=10)
/no_attrs/Batch-16    470.7n ±  6%   436.2n ±  2%  -7.33% (p=0.000 n=10)
/3_attrs/Simple-16    653.2n ±  5%   661.8n ±  7%       ~ (p=0.280 n=10)
/3_attrs/Batch-16     687.9n ±  6%   660.4n ±  8%       ~ (p=0.436 n=10)
/5_attrs/Simple-16    767.1n ±  4%   779.6n ±  3%       ~ (p=0.165 n=10)
/5_attrs/Batch-16     833.2n ±  3%   772.5n ±  4%  -7.28% (p=0.000 n=10)
/10_attrs/Simple-16   2.076µ ±  3%   2.026µ ±  6%       ~ (p=0.210 n=10)
/10_attrs/Batch-16    2.489µ ±  7%   2.347µ ±  5%       ~ (p=0.063 n=10)
/40_attrs/Simple-16   6.010µ ±  4%   6.459µ ± 13%  +7.46% (p=0.005 n=10)
/40_attrs/Batch-16    8.201µ ± 10%   7.848µ ±  5%       ~ (p=0.165 n=10)
geomean               1.316µ         1.288µ        -2.12%

                    │    old.txt     │                new.txt                │
                    │      B/op      │     B/op      vs base                 │
/no_attrs/Simple-16     0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
/no_attrs/Batch-16      0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
/3_attrs/Simple-16      0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
/3_attrs/Batch-16       1.000 ± 0%       1.000 ±  ?       ~ (p=0.303 n=10)
/5_attrs/Simple-16      0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
/5_attrs/Batch-16       1.000 ± 0%       1.000 ± 0%       ~ (p=1.000 n=10) ¹
/10_attrs/Simple-16   1.392Ki ± 0%     1.392Ki ± 0%       ~ (p=1.000 n=10) ¹
/10_attrs/Batch-16    1.396Ki ± 0%     1.394Ki ± 0%  -0.14% (p=0.000 n=10)
/40_attrs/Simple-16   6.692Ki ± 0%     6.692Ki ± 0%       ~ (p=1.000 n=10) ¹
/40_attrs/Batch-16    6.705Ki ± 0%     6.699Ki ± 0%  -0.08% (p=0.000 n=10)
geomean                            ²                 -0.02%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                    │   old.txt    │               new.txt               │
                    │  allocs/op   │ allocs/op   vs base                 │
/no_attrs/Simple-16   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
/no_attrs/Batch-16    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
/3_attrs/Simple-16    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
/3_attrs/Batch-16     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
/5_attrs/Simple-16    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
/5_attrs/Batch-16     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
/10_attrs/Simple-16   9.000 ± 0%     9.000 ± 0%       ~ (p=1.000 n=10) ¹
/10_attrs/Batch-16    9.000 ± 0%     9.000 ± 0%       ~ (p=1.000 n=10) ¹
/40_attrs/Simple-16   13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
/40_attrs/Batch-16    13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                          ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

Yet it makes implementing decorators that e.g. alters a log record simpler.

Without `Processor`:

```go
var pool = sync.Pool{
	New: func() any {
		b := make([]Record, 0, 1)
		return &b
	},
}

type timestampDecorator struct {
	Exporter
}

func (e timestampDecorator) Export(ctx context.Context, records []Record) error {
	bPtr := pool.Get().(*[]Record)
	defer func() {
		*bPtr = (*bPtr)[:0]
		pool.Put(bPtr)
	}()
	b := *bPtr

	for _, r := range records {
		r = r.Clone()
		r.SetObservedTimestamp(time.Date(1988, time.November, 17, 0, 0, 0, 0, time.UTC))
		b = append(b, r)
	}

	return e.Exporter.Export(ctx, b)
}
```


With `Processor`: 

```go
type timestampDecorator struct {
	Exporter
}

func (e timestampDecorator) Export(ctx context.Context, records []Record) error {
	bPtr := pool.Get().(*[]Record)
	defer func() {
		*bPtr = (*bPtr)[:0]
		pool.Put(bPtr)
	}()
	b := *bPtr

	for _, r := range records {
		r = r.Clone()
		r.SetObservedTimestamp(testTimestamp)
		b = append(b, r)
	}

	return e.Exporter.Export(ctx, b)
}
```