### PR TITLE
Add TracerProvider option to disable panic exception recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Add `WithoutPanicRecording` TracerProvider option in `go.opentelemetry.io/otel/sdk/trace` to disable exception event recording for panics.
 - Add `Map` and `MapValue` functions for new `MAP` attribute type in `go.opentelemetry.io/otel/attribute`. (#8445)
 - Support `MAP` attributes in `go.opentelemetry.io/otel/exporters/otlp/otlptrace`. (#8453)
 - Support `MAP` attributes in `go.opentelemetry.io/otel/exporters/otlp/otlplog`. (#8453)

--- a/sdk/trace/provider.go
+++ b/sdk/trace/provider.go
@@ -43,22 +43,27 @@ type tracerProviderConfig struct {
 
 	// resource contains attributes representing an entity that produces telemetry.
 	resource *resource.Resource
+
+	// panicRecordingDisabled disables recording exception events from panics.
+	panicRecordingDisabled bool
 }
 
 // MarshalLog is the marshaling function used by the logging system to represent this Provider.
 func (cfg tracerProviderConfig) MarshalLog() any {
 	return struct {
-		SpanProcessors  []SpanProcessor
-		SamplerType     string
-		IDGeneratorType string
-		SpanLimits      SpanLimits
-		Resource        *resource.Resource
+		SpanProcessors         []SpanProcessor
+		SamplerType            string
+		IDGeneratorType        string
+		SpanLimits             SpanLimits
+		Resource               *resource.Resource
+		PanicRecordingDisabled bool
 	}{
-		SpanProcessors:  cfg.processors,
-		SamplerType:     fmt.Sprintf("%T", cfg.sampler),
-		IDGeneratorType: fmt.Sprintf("%T", cfg.idGenerator),
-		SpanLimits:      cfg.spanLimits,
-		Resource:        cfg.resource,
+		SpanProcessors:         cfg.processors,
+		SamplerType:            fmt.Sprintf("%T", cfg.sampler),
+		IDGeneratorType:        fmt.Sprintf("%T", cfg.idGenerator),
+		SpanLimits:             cfg.spanLimits,
+		Resource:               cfg.resource,
+		PanicRecordingDisabled: cfg.panicRecordingDisabled,
 	}
 }
 
@@ -75,10 +80,11 @@ type TracerProvider struct {
 
 	// These fields are not protected by the lock mu. They are assumed to be
 	// immutable after creation of the TracerProvider.
-	sampler     Sampler
-	idGenerator IDGenerator
-	spanLimits  SpanLimits
-	resource    *resource.Resource
+	sampler                Sampler
+	idGenerator            IDGenerator
+	spanLimits             SpanLimits
+	resource               *resource.Resource
+	panicRecordingDisabled bool
 }
 
 var _ trace.TracerProvider = &TracerProvider{}
@@ -113,11 +119,12 @@ func NewTracerProvider(opts ...TracerProviderOption) *TracerProvider {
 	o = ensureValidTracerProviderConfig(o)
 
 	tp := &TracerProvider{
-		namedTracer: make(map[instrumentation.Scope]*tracer),
-		sampler:     o.sampler,
-		idGenerator: o.idGenerator,
-		spanLimits:  o.spanLimits,
-		resource:    o.resource,
+		namedTracer:            make(map[instrumentation.Scope]*tracer),
+		sampler:                o.sampler,
+		idGenerator:            o.idGenerator,
+		spanLimits:             o.spanLimits,
+		resource:               o.resource,
+		panicRecordingDisabled: o.panicRecordingDisabled,
 	}
 	global.Info("TracerProvider created", "config", o)
 
@@ -355,6 +362,16 @@ func WithBatcher(e SpanExporter, opts ...BatchSpanProcessorOption) TracerProvide
 func WithSpanProcessor(sp SpanProcessor) TracerProviderOption {
 	return traceProviderOptionFunc(func(cfg tracerProviderConfig) tracerProviderConfig {
 		cfg.processors = append(cfg.processors, sp)
+		return cfg
+	})
+}
+
+// WithoutPanicRecording configures the TracerProvider to not record exception
+// events when a Span is ended while panicking. The panic continues to
+// propagate, and the span is ended without adding the event.
+func WithoutPanicRecording() TracerProviderOption {
+	return traceProviderOptionFunc(func(cfg tracerProviderConfig) tracerProviderConfig {
+		cfg.panicRecordingDisabled = true
 		return cfg
 	})
 }

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -577,11 +577,12 @@ func truncate(limit int, s string) string {
 // End ends the span. This method does nothing if the span is already ended or
 // is not being recorded.
 //
-// The only SpanEndOption currently supported are [trace.WithTimestamp], and
+// The only SpanEndOption currently supported are [trace.WithTimestamp] and
 // [trace.WithStackTrace].
 //
-// If this method is called while panicking an error event is added to the
-// Span before ending it and the panic is continued.
+// If this method is called while panicking and panic recording is not disabled
+// on the TracerProvider, an error event is added to the Span before ending it
+// and the panic is continued.
 func (s *recordingSpan) End(options ...trace.SpanEndOption) {
 	// Do not start by checking if the span is being recorded which requires
 	// acquiring a lock. Make a minimal check that the span is not nil.
@@ -601,23 +602,25 @@ func (s *recordingSpan) End(options ...trace.SpanEndOption) {
 	}
 
 	config := trace.NewSpanEndConfig(options...)
-	if recovered := recover(); recovered != nil {
-		// Record but don't stop the panic.
-		defer panic(recovered)
-		opts := []trace.EventOption{
-			trace.WithAttributes(
-				semconv.ExceptionType(typeStr(recovered)),
-				semconv.ExceptionMessage(fmt.Sprint(recovered)),
-			),
-		}
+	if !s.tracer.provider.panicRecordingDisabled {
+		if recovered := recover(); recovered != nil {
+			// Record but don't stop the panic.
+			defer panic(recovered)
+			opts := []trace.EventOption{
+				trace.WithAttributes(
+					semconv.ExceptionType(typeStr(recovered)),
+					semconv.ExceptionMessage(fmt.Sprint(recovered)),
+				),
+			}
 
-		if config.StackTrace() {
-			opts = append(opts, trace.WithAttributes(
-				semconv.ExceptionStacktrace(recordStackTrace()),
-			))
-		}
+			if config.StackTrace() {
+				opts = append(opts, trace.WithAttributes(
+					semconv.ExceptionStacktrace(recordStackTrace()),
+				))
+			}
 
-		s.addEvent(semconv.ExceptionEventName, opts...)
+			s.addEvent(semconv.ExceptionEventName, opts...)
+		}
 	}
 
 	if s.executionTracerTaskEnd != nil {

--- a/sdk/trace/span.go
+++ b/sdk/trace/span.go
@@ -577,9 +577,7 @@ func truncate(limit int, s string) string {
 // End ends the span. This method does nothing if the span is already ended or
 // is not being recorded.
 //
-// The only SpanEndOption currently supported are [trace.WithTimestamp] and
-// [trace.WithStackTrace].
-//
+// The only supported SpanEndOptions are [trace.WithTimestamp] and [trace.WithStackTrace].
 // If this method is called while panicking and panic recording is not disabled
 // on the TracerProvider, an error event is added to the Span before ending it
 // and the panic is continued.

--- a/sdk/trace/trace_test.go
+++ b/sdk/trace/trace_test.go
@@ -1620,6 +1620,24 @@ func TestSpanCapturesPanic(t *testing.T) {
 	}, spans[0].Events()[0].Attributes)
 }
 
+func TestSpanWithoutPanicRecording(t *testing.T) {
+	te := NewTestExporter()
+	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()), WithoutPanicRecording())
+	_, span := tp.Tracer("CatchPanic").Start(
+		t.Context(),
+		"span",
+	)
+
+	f := func() {
+		defer span.End()
+		panic(errors.New("error message"))
+	}
+	require.PanicsWithError(t, "error message", f)
+	spans := te.Spans()
+	require.Len(t, spans, 1)
+	assert.Empty(t, spans[0].Events())
+}
+
 func TestSpanCapturesPanicWithStackTrace(t *testing.T) {
 	te := NewTestExporter()
 	tp := NewTracerProvider(WithSyncer(te), WithResource(resource.Empty()))


### PR DESCRIPTION
### Motivation

Provide an opt-out to avoid automatically recording exception events when a span ends during a panic, for users who do not want those events emitted. 

### Changes

- Introduce `WithoutPanicRecording()` returning a `TracerProviderOption` that sets the `panicRecordingDisabled` flag. 
- Include `PanicRecordingDisabled` in `MarshalLog` output. 
- Change `recordingSpan.End` to skip adding exception events on panic when `s.tracer.provider.panicRecordingDisabled` is true. 
